### PR TITLE
Fix file download return type, add files API tests, and centralize beta header

### DIFF
--- a/config/claude.php
+++ b/config/claude.php
@@ -9,5 +9,6 @@ return [
     'temperature' => env('CLAUDE_TEMPERATURE', 1.0),
     'timeout' => env('CLAUDE_TIMEOUT', 60),
     'retries' => env('CLAUDE_RETRIES', 1),
+    'files_beta_version' => env('CLAUDE_FILES_BETA_VERSION', 'files-api-2025-04-14'),
 ];
 

--- a/tests/Feature/FilesApiTest.php
+++ b/tests/Feature/FilesApiTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use GaalGergely\LaravelClaude\Clients\HttpClaudeClient;
+use Illuminate\Support\Facades\Http;
+
+it('sends the beta header for all file endpoints', function () {
+    Http::fake([
+        'https://api.anthropic.com/*' => Http::response(['ok' => true], 200),
+    ]);
+
+    $client = new HttpClaudeClient();
+
+    $client->createFile([
+        'content' => 'hello world',
+        'name' => 'example.txt',
+        'purpose' => 'fine-tune',
+    ]);
+
+    $client->listFiles();
+    $client->getFileMetadata('file_123');
+    $client->downloadFile('file_123');
+    $client->deleteFile('file_123');
+
+    Http::assertSentCount(5);
+
+    foreach (Http::recorded() as [$request, $_response]) {
+        expect($request->hasHeader('anthropic-beta', config('claude.files_beta_version')))->toBeTrue();
+    }
+});
+
+it('returns the downloadFile response body as a string', function () {
+    Http::fake([
+        'https://api.anthropic.com/files/*/content' => Http::response('file-contents', 200),
+    ]);
+
+    $client = new HttpClaudeClient();
+
+    $content = $client->downloadFile('file_abc');
+
+    expect($content)->toBe('file-contents');
+});


### PR DESCRIPTION
## Summary
- return file downloads as response body strings to match the contract
- add coverage for beta files endpoints and download response handling
- centralize the files beta version header configuration across endpoints

## Testing
- Not run (composer install requires GitHub token to download dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab355dd788321a2fd81074206633a)