### PR TITLE
Add official Claude API references to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Access the service through the `Claude` facade or via dependency injection.
 
 ### Quick message example
 
+Reference: [Claude Messages API](https://platform.claude.com/docs/en/api/messages/overview)
+
 ```php
 use GaalGergely\LaravelClaude\Facades\Claude;
 
@@ -67,6 +69,8 @@ $text = data_get($response, 'content.0.text');
 
 ### Streaming responses
 
+Reference: [Claude Messages Streaming](https://platform.claude.com/docs/en/api/messages/streaming)
+
 ```php
 $events = Claude::sendMessages([
     'messages' => [
@@ -82,6 +86,8 @@ foreach ($events as $event) {
 
 ### Counting tokens
 
+Reference: [Count Message Tokens](https://platform.claude.com/docs/en/api/messages/count_tokens)
+
 ```php
 $result = Claude::countMessageTokens([
     'messages' => [
@@ -94,12 +100,20 @@ $tokenCount = $result['input_tokens'] ?? null;
 
 ### Querying models
 
+Reference: [Models API](https://platform.claude.com/docs/en/api/models/overview)
+
 ```php
 $models = Claude::listModels(limit: 20);
 $opus = Claude::getModel('claude-3-opus-20240229');
+
+// Paginate forward or backward with cursor-style parameters
+$nextPage = Claude::listModels(afterId: data_get($models, 'last_id'));
+$previousPage = Claude::listModels(beforeId: data_get($models, 'first_id'));
 ```
 
 ### Message batches
+
+Reference: [Message Batches API](https://platform.claude.com/docs/en/api/message_batches/overview)
 
 ```php
 $batch = Claude::createMessageBatch([
@@ -117,9 +131,15 @@ $batch = Claude::createMessageBatch([
 
 $status = Claude::retrieveMessageBatch($batch['id']);
 $results = Claude::retrieveMessageBatchResults($batch['id']);
+
+// List batches with cursor pagination
+$batches = Claude::listMessageBatches(limit: 10);
+$olderBatches = Claude::listMessageBatches(afterId: data_get($batches, 'last_id'));
 ```
 
 ### File operations
+
+Reference: [Files API](https://platform.claude.com/docs/en/api/files/overview)
 
 ```php
 $file = Claude::createFile([
@@ -131,6 +151,9 @@ $files = Claude::listFiles();
 $metadata = Claude::getFileMetadata($file['id']);
 $content = Claude::downloadFile($file['id']);
 Claude::deleteFile($file['id']);
+
+// Use cursor-style pagination to browse more files
+$moreFiles = Claude::listFiles(afterId: data_get($files, 'last_id'), limit: 20);
 ```
 
 ## Validation and error handling


### PR DESCRIPTION
## Summary
- add reference links to official Claude API docs for messages, streaming, token counting, models, batches, and files sections in README

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d648e57848321ade108f9636dd35d)